### PR TITLE
FIX: Correct action binding for banner buttons

### DIFF
--- a/javascripts/discourse/components/dismissable-banner.gjs
+++ b/javascripts/discourse/components/dismissable-banner.gjs
@@ -62,11 +62,11 @@ export default class DismissableBanner extends Component {
           </div>
           <div class="discourse-signup-banner-cta-actions">
             <DButton
-              @action="showBannerLater"
+              @action={{this.showBannerLater}}
               @translatedLabel={{settings.reminder_text}}
             />
             <DButton
-              @action="dismissBanner"
+              @action={{this.dismissBanner}}
               @translatedLabel={{settings.dismiss_text}}
             />
           </div>


### PR DESCRIPTION
Previously, `@action="showBannerLater"` and similar strings were used for button actions, which don’t work correctly in Ember Octane-style components. As a result, the actions weren’t invoked.

This PR switches to using `@action={{this.showBannerLater}}` and `@action={{this.dismissBanner}}` to properly bind to the class methods.

Tested locally with anonymous users — the banner actions now work as expected.
